### PR TITLE
Add base theme and css options 

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -7,6 +7,7 @@ const config: StorybookConfig = {
     '@storybook/addon-essentials',
     '@chromatic-com/storybook',
     '@storybook/addon-interactions',
+    '@storybook/addon-viewport'
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@storybook/addon-essentials": "^8.4.2",
     "@storybook/addon-interactions": "^8.4.2",
     "@storybook/addon-onboarding": "^8.4.2",
+    "@storybook/addon-viewport": "^8.4.4",
     "@storybook/blocks": "^8.4.2",
     "@storybook/react": "^8.4.2",
     "@storybook/react-vite": "^8.4.2",

--- a/src/components/Container/Container.styles.ts
+++ b/src/components/Container/Container.styles.ts
@@ -1,38 +1,9 @@
 import styled from 'styled-components'
-import { mediaQueries } from '../../utils/breakpoints'
+import { generateResponsiveStyles, ResponsiveProps } from '../../utils/responsive'
 
-export const ContainerWrapper = styled.div<{
-  responsive?: {
-    small?: Partial<CSSStyleDeclaration>
-    medium?: Partial<CSSStyleDeclaration>
-    large?: Partial<CSSStyleDeclaration>
-    xl?: Partial<CSSStyleDeclaration>
-  }
-}>`
+export const ContainerWrapper = styled.div<{ responsive?: ResponsiveProps }>`
   box-sizing: border-box;
   flex-direction: column;
 
-  ${({ responsive }) => responsive?.small && `
-    ${mediaQueries.small} {
-      ${Object.entries(responsive.small).map(([key, value]) => `${key}: ${value} !important;`).join('\n')}
-    }
-  `}
-
-  ${({ responsive }) => responsive?.medium && `
-    ${mediaQueries.medium} {
-      ${Object.entries(responsive.medium).map(([key, value]) => `${key}: ${value} !important;`).join('\n')}
-    }
-  `}
-
-  ${({ responsive }) => responsive?.large && `
-    ${mediaQueries.large} {
-      ${Object.entries(responsive.large).map(([key, value]) => `${key}: ${value} !important;`).join('\n')}
-    }
-  `}
-
-  ${({ responsive }) => responsive?.xl && `
-    ${mediaQueries.xl} {
-      ${Object.entries(responsive.xl).map(([key, value]) => `${key}: ${value} !important;`).join('\n')}
-    }
-  `}
+  ${({ responsive }) => generateResponsiveStyles(responsive)}
 `

--- a/src/components/Container/Container.styles.ts
+++ b/src/components/Container/Container.styles.ts
@@ -1,7 +1,38 @@
-import styled from 'styled-components';
+import styled from 'styled-components'
+import { mediaQueries } from '../../utils/breakpoints'
 
-export const ContainerWrapper = styled.div`
+export const ContainerWrapper = styled.div<{
+  responsive?: {
+    small?: Partial<CSSStyleDeclaration>
+    medium?: Partial<CSSStyleDeclaration>
+    large?: Partial<CSSStyleDeclaration>
+    xl?: Partial<CSSStyleDeclaration>
+  }
+}>`
   box-sizing: border-box;
   flex-direction: column;
-  width: 100%
-  `;
+
+  ${({ responsive }) => responsive?.small && `
+    ${mediaQueries.small} {
+      ${Object.entries(responsive.small).map(([key, value]) => `${key}: ${value} !important;`).join('\n')}
+    }
+  `}
+
+  ${({ responsive }) => responsive?.medium && `
+    ${mediaQueries.medium} {
+      ${Object.entries(responsive.medium).map(([key, value]) => `${key}: ${value} !important;`).join('\n')}
+    }
+  `}
+
+  ${({ responsive }) => responsive?.large && `
+    ${mediaQueries.large} {
+      ${Object.entries(responsive.large).map(([key, value]) => `${key}: ${value} !important;`).join('\n')}
+    }
+  `}
+
+  ${({ responsive }) => responsive?.xl && `
+    ${mediaQueries.xl} {
+      ${Object.entries(responsive.xl).map(([key, value]) => `${key}: ${value} !important;`).join('\n')}
+    }
+  `}
+`

--- a/src/components/Container/Container.styles.ts
+++ b/src/components/Container/Container.styles.ts
@@ -1,8 +1,7 @@
 import styled from 'styled-components';
 
 export const ContainerWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
   box-sizing: border-box;
-`;
+  flex-direction: column;
+  width: 100%
+  `;

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -8,15 +8,23 @@ interface ContainerProps {
   backgroundColor?: string
   border?: string
   borderRadius?: string
+  display?: string
+  justifyContent?: string
+  alignItems?: string
+  height?: string
 }
 
 export default function Container({
   children,
-  padding = '16px',          // Default padding
-  margin = '0',               // Default margin
-  backgroundColor = 'inherit', // Default to inherit background color
-  border = 'none',            // Default border
-  borderRadius = '0'          // Default border radius
+  padding = '16px',
+  margin = '0',
+  backgroundColor = 'inherit',
+  border = 'none',
+  borderRadius = '0',
+  display = 'flex',          // Default to flex for Container
+  justifyContent,            // Optional, no default
+  alignItems,                // Optional, no default
+  height,                    // Optional, no default
 }: ContainerProps) {
   return (
     <ContainerWrapper
@@ -25,7 +33,11 @@ export default function Container({
         margin,
         backgroundColor,
         border,
-        borderRadius
+        borderRadius,
+        display,
+        justifyContent,
+        alignItems,
+        height,
       }}
     >
       {children}

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -1,12 +1,6 @@
 import { ReactNode } from 'react'
 import { ContainerWrapper } from './Container.styles'
-
-interface ResponsiveProps {
-  small?: Partial<CSSStyleDeclaration>
-  medium?: Partial<CSSStyleDeclaration>
-  large?: Partial<CSSStyleDeclaration>
-  xl?: Partial<CSSStyleDeclaration>
-}
+import { ResponsiveProps } from '../../utils/responsive'
 
 interface ContainerProps {
   children: ReactNode

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -1,5 +1,12 @@
-import { ReactNode } from 'react';
-import { ContainerWrapper } from './Container.styles.ts';
+import { ReactNode } from 'react'
+import { ContainerWrapper } from './Container.styles'
+
+interface ResponsiveProps {
+  small?: Partial<CSSStyleDeclaration>
+  medium?: Partial<CSSStyleDeclaration>
+  large?: Partial<CSSStyleDeclaration>
+  xl?: Partial<CSSStyleDeclaration>
+}
 
 interface ContainerProps {
   children: ReactNode
@@ -12,6 +19,8 @@ interface ContainerProps {
   justifyContent?: string
   alignItems?: string
   height?: string
+  width?: string
+  responsive?: ResponsiveProps
 }
 
 export default function Container({
@@ -21,10 +30,12 @@ export default function Container({
   backgroundColor = 'inherit',
   border = 'none',
   borderRadius = '0',
-  display = 'flex',          // Default to flex for Container
-  justifyContent,            // Optional, no default
-  alignItems,                // Optional, no default
-  height,                    // Optional, no default
+  display = 'flex',
+  justifyContent,
+  alignItems,
+  height,
+  width = '100%',
+  responsive,
 }: ContainerProps) {
   return (
     <ContainerWrapper
@@ -38,7 +49,9 @@ export default function Container({
         justifyContent,
         alignItems,
         height,
+        width,
       }}
+      responsive={responsive}
     >
       {children}
     </ContainerWrapper>

--- a/src/components/Header/Header.styles.ts
+++ b/src/components/Header/Header.styles.ts
@@ -1,9 +1,8 @@
 import styled from 'styled-components'
 
-export const HeaderWrapper = styled.h1<{ center?: boolean; font?: string; fontSize?: string; color?: string }>`
-  font-size: ${({ fontSize, theme, as }) => fontSize || theme.fontSizes[as || 'h1']};
-  font-family: ${({ font, theme }) => font || theme.fonts.header};
-  color: ${({ color, theme }) => color || theme.colors.header};
-  text-align: ${({ center }) => (center ? 'center' : 'left')};
+export const HeaderWrapper = styled.h1`
   margin: 0;
+  font-size: ${({ theme, as }) => theme.fontSizes[as || 'h1']}; // Default font size from theme
+  color: ${({ theme }) => theme.colors.header};                // Default color from theme
+  font-family: ${({ theme }) => theme.fonts.header};           // Default font family from theme
 `

--- a/src/components/Header/Header.styles.ts
+++ b/src/components/Header/Header.styles.ts
@@ -1,8 +1,11 @@
 import styled from 'styled-components'
+import { generateResponsiveStyles, ResponsiveProps } from '../../utils/responsive'
 
-export const HeaderWrapper = styled.h1`
-  margin: 0;
+export const HeaderWrapper = styled.h1<{ responsive?: ResponsiveProps }>`
   font-size: ${({ theme, as }) => theme.fontSizes[as || 'h1']}; // Default font size from theme
   color: ${({ theme }) => theme.colors.header};                // Default color from theme
   font-family: ${({ theme }) => theme.fonts.header};           // Default font family from theme
+  margin: 0;
+
+  ${({ responsive }) => generateResponsiveStyles(responsive)}
 `

--- a/src/components/Header/Header.styles.ts
+++ b/src/components/Header/Header.styles.ts
@@ -1,7 +1,9 @@
 import styled from 'styled-components'
 
-export const HeaderWrapper = styled.h1<{ center?: boolean }>`
-  font-size: 24px;
+export const HeaderWrapper = styled.h1<{ center?: boolean; font?: string; fontSize?: string; color?: string }>`
+  font-size: ${({ fontSize, theme, as }) => fontSize || theme.fontSizes[as || 'h1']};
+  font-family: ${({ font, theme }) => font || theme.fonts.header};
+  color: ${({ color, theme }) => color || theme.colors.header};
   text-align: ${({ center }) => (center ? 'center' : 'left')};
   margin: 0;
 `

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, CSSProperties } from 'react'
 import { HeaderWrapper } from './Header.styles'
+import { ResponsiveProps } from '../../utils/responsive'
 
 interface HeaderProps {
   children: ReactNode
@@ -8,6 +9,7 @@ interface HeaderProps {
   fontFamily?: CSSProperties['fontFamily']
   fontSize?: CSSProperties['fontSize']
   color?: CSSProperties['color']
+  responsive?: ResponsiveProps
 }
 
 export default function Header({
@@ -17,6 +19,7 @@ export default function Header({
   fontFamily,
   fontSize,
   color,
+  responsive
 }: HeaderProps) {
   return (
     <HeaderWrapper
@@ -27,6 +30,7 @@ export default function Header({
         fontSize,
         color,
       }}
+      responsive={responsive}
     >
       {children}
     </HeaderWrapper>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,25 +1,33 @@
-import { ReactNode } from 'react'
-import { HeaderWrapper } from './Header.styles.ts'
+import { ReactNode, CSSProperties } from 'react'
+import { HeaderWrapper } from './Header.styles'
 
-type HeaderProps = {
+interface HeaderProps {
   children: ReactNode
-  center?: boolean
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' // Dynamic header type
-  font?: string
-  fontSize?: string
-  color?: string
+  textAlign?: CSSProperties['textAlign']
+  fontFamily?: CSSProperties['fontFamily']
+  fontSize?: CSSProperties['fontSize']
+  color?: CSSProperties['color']
 }
 
 export default function Header({
   children,
-  center = false,
   as = 'h1', // Default to h1
-  font,
+  textAlign,
+  fontFamily,
   fontSize,
-  color
+  color,
 }: HeaderProps) {
   return (
-    <HeaderWrapper as={as} center={center} font={font} fontSize={fontSize} color={color}>
+    <HeaderWrapper
+      as={as}
+      style={{
+        textAlign,
+        fontFamily,
+        fontSize,
+        color,
+      }}
+    >
       {children}
     </HeaderWrapper>
   )

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,8 +4,23 @@ import { HeaderWrapper } from './Header.styles.ts'
 type HeaderProps = {
   children: ReactNode
   center?: boolean
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' // Dynamic header type
+  font?: string
+  fontSize?: string
+  color?: string
 }
 
-export default function Header({ children, center = false }: HeaderProps) {
-  return <HeaderWrapper center={center}>{children}</HeaderWrapper>
+export default function Header({
+  children,
+  center = false,
+  as = 'h1', // Default to h1
+  font,
+  fontSize,
+  color
+}: HeaderProps) {
+  return (
+    <HeaderWrapper as={as} center={center} font={font} fontSize={fontSize} color={color}>
+      {children}
+    </HeaderWrapper>
+  )
 }

--- a/src/components/Main.stories.tsx
+++ b/src/components/Main.stories.tsx
@@ -16,28 +16,40 @@ export const TestPage = () => (
   <ThemeProvider theme={baseTheme}>
     <Container border='1px solid black'>
       <Row>
-        <Header center>Welcome to Jesko</Header>
+        <Container padding='0px'>
+          <Header textAlign='center'>Welcome to Jesko</Header>
+        </Container>
       </Row>
       <Row>
         <Container border='1px solid blue'>
           <Row>
             <Column width="25%">
               <Container border='1px solid red' padding='0px'>
-                <Header>Hello 4</Header>
-                <Paragraph center>Column 1</Paragraph>
+                <Header textAlign='center'>Hello 4</Header>
+                <Paragraph textAlign="center">Column 1</Paragraph>
               </Container>
             </Column>
             <Column width="25%">
               <Header>Hello 4</Header>
-              <Paragraph center>Column 2</Paragraph>
+              <Paragraph  textAlign="center">Column 2</Paragraph>
             </Column>
             <Column width="25%">
               <Header>Hello 4</Header>
-              <Paragraph center>Column 3</Paragraph>
+              <Paragraph  textAlign="center">Column 3</Paragraph>
             </Column>
             <Column width="25%">
               <Header>Hello 4</Header>
-              <Paragraph center>Column 4</Paragraph>
+              <Paragraph  textAlign="center">Column 4</Paragraph>
+            </Column>
+          </Row>
+          <Row>
+            <Column width="50%">
+                <Header>Hello 4</Header>
+                <Paragraph  textAlign="center">Column 1</Paragraph>
+            </Column>
+            <Column width="50%">
+              <Header>Hello 4</Header>
+              <Paragraph  textAlign="center">Column 2</Paragraph>
             </Column>
           </Row>
         </Container>
@@ -53,12 +65,23 @@ export const LoginPage = () => (
     justifyContent="center"
     alignItems="center"
     height="100vh"
-
+    border='1px solid black'
     >
-      <Header 
-      center
-      as="h2"
-      >Login Here</Header>
+      <Container
+      width='50%'
+      border='2px solid blue'
+      responsive={{
+        small: { width: '90%' },
+        medium: { width: '80%' }
+      }}
+      >
+        <Header 
+        textAlign='center'
+        as="h2"
+        >Login Here</Header>
+        <Header as='h3'>Username: ___________</Header>
+        <Header as='h3'>Password: ___________</Header>
+      </Container>
     </Container>
   </ThemeProvider>
 )
@@ -72,7 +95,7 @@ export const BasicThemePage = () => (
     height="100vh"
     >
       <Header 
-        center
+        textAlign='center'
         as="h2"
       >Login Here</Header>
     </Container>

--- a/src/components/Main.stories.tsx
+++ b/src/components/Main.stories.tsx
@@ -3,6 +3,9 @@ import Row from './Row/Row'
 import Column from './Column/Column'
 import Header from './Header/Header'
 import Paragraph from './Paragraph/Paragraph'
+import baseTheme from '../theme/base-theme'
+import testTheme from '../theme/test-theme'
+import { ThemeProvider } from 'styled-components'
 
 export default {
   title: 'Components/Main',
@@ -10,27 +13,68 @@ export default {
 }
 
 export const TestPage = () => (
-  <Container>
-    <Row>
-      <Header center>Welcome to Jesko</Header>
-    </Row>
-    <Row>
-      <Container>
-        <Row>
-          <Column width="25%">
-            <Paragraph center>Column 1</Paragraph>
-          </Column>
-          <Column width="25%">
-            <Paragraph center>Column 2</Paragraph>
-          </Column>
-          <Column width="25%">
-            <Paragraph center>Column 3</Paragraph>
-          </Column>
-          <Column width="25%">
-            <Paragraph center>Column 4</Paragraph>
-          </Column>
-        </Row>
-      </Container>
-    </Row>
-  </Container>
+  <ThemeProvider theme={baseTheme}>
+    <Container border='1px solid black'>
+      <Row>
+        <Header center>Welcome to Jesko</Header>
+      </Row>
+      <Row>
+        <Container border='1px solid blue'>
+          <Row>
+            <Column width="25%">
+              <Container border='1px solid red' padding='0px'>
+                <Header>Hello 4</Header>
+                <Paragraph center>Column 1</Paragraph>
+              </Container>
+            </Column>
+            <Column width="25%">
+              <Header>Hello 4</Header>
+              <Paragraph center>Column 2</Paragraph>
+            </Column>
+            <Column width="25%">
+              <Header>Hello 4</Header>
+              <Paragraph center>Column 3</Paragraph>
+            </Column>
+            <Column width="25%">
+              <Header>Hello 4</Header>
+              <Paragraph center>Column 4</Paragraph>
+            </Column>
+          </Row>
+        </Container>
+      </Row>
+    </Container>
+  </ThemeProvider>
+)
+
+export const LoginPage = () => (
+  <ThemeProvider theme={baseTheme}>
+    <Container
+    backgroundColor="white"
+    justifyContent="center"
+    alignItems="center"
+    height="100vh"
+
+    >
+      <Header 
+      center
+      as="h2"
+      >Login Here</Header>
+    </Container>
+  </ThemeProvider>
+)
+
+export const BasicThemePage = () => (
+  <ThemeProvider theme={testTheme}>
+    <Container
+    backgroundColor="white"
+    justifyContent="center"
+    alignItems="center"
+    height="100vh"
+    >
+      <Header 
+        center
+        as="h2"
+      >Login Here</Header>
+    </Container>
+  </ThemeProvider>
 )

--- a/src/components/Main.stories.tsx
+++ b/src/components/Main.stories.tsx
@@ -79,8 +79,8 @@ export const LoginPage = () => (
         textAlign='center'
         as="h2"
         >Login Here</Header>
-        <Header as='h3'>Username: ___________</Header>
-        <Header as='h3'>Password: ___________</Header>
+        <Header as='h3' responsive={{small: { color: 'red'}}}>Username: ___________</Header>
+        <Header as='h3' responsive={{large: { color: 'purple' }}}>Password: ___________</Header>
       </Container>
     </Container>
   </ThemeProvider>

--- a/src/components/Paragraph/Paragraph.styles.ts
+++ b/src/components/Paragraph/Paragraph.styles.ts
@@ -1,7 +1,8 @@
 import styled from 'styled-components'
 
-export const ParagraphWrapper = styled.p<{ center?: boolean }>`
-  font-size: 16px;
-  text-align: ${({ center }) => (center ? 'center' : 'left')};
+export const ParagraphWrapper = styled.p`
   margin: 0;
+  font-size: ${({ theme }) => theme.fontSizes.paragraph}; // Default font size from theme
+  color: ${({ theme }) => theme.colors.paragraph};       // Default color from theme
+  font-family: ${({ theme }) => theme.fonts.paragraph}; // Default font family from theme
 `

--- a/src/components/Paragraph/Paragraph.styles.ts
+++ b/src/components/Paragraph/Paragraph.styles.ts
@@ -1,8 +1,11 @@
 import styled from 'styled-components'
+import { generateResponsiveStyles, ResponsiveProps } from '../../utils/responsive'
 
-export const ParagraphWrapper = styled.p`
-  margin: 0;
+export const ParagraphWrapper = styled.p<{ responsive?: ResponsiveProps }>`
   font-size: ${({ theme }) => theme.fontSizes.paragraph}; // Default font size from theme
   color: ${({ theme }) => theme.colors.paragraph};       // Default color from theme
   font-family: ${({ theme }) => theme.fonts.paragraph}; // Default font family from theme
+  margin: 0;
+
+  ${({ responsive }) => generateResponsiveStyles(responsive)}
 `

--- a/src/components/Paragraph/Paragraph.tsx
+++ b/src/components/Paragraph/Paragraph.tsx
@@ -1,11 +1,31 @@
-import { ReactNode } from 'react'
+import { ReactNode, CSSProperties } from 'react'
 import { ParagraphWrapper } from './Paragraph.styles'
 
-type ParagraphProps = {
+interface ParagraphProps {
   children: ReactNode
-  center?: boolean
+  textAlign?: CSSProperties['textAlign']
+  color?: CSSProperties['color']
+  fontFamily?: CSSProperties['fontFamily']
+  fontSize?: CSSProperties['fontSize']
 }
 
-export default function Paragraph({ children, center = false }: ParagraphProps) {
-  return <ParagraphWrapper center={center}>{children}</ParagraphWrapper>
+export default function Paragraph({
+  children,
+  textAlign,
+  color,
+  fontFamily,
+  fontSize,
+}: ParagraphProps) {
+  return (
+    <ParagraphWrapper
+      style={{
+        textAlign,
+        color,
+        fontFamily,
+        fontSize,
+      }}
+    >
+      {children}
+    </ParagraphWrapper>
+  )
 }

--- a/src/components/Paragraph/Paragraph.tsx
+++ b/src/components/Paragraph/Paragraph.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, CSSProperties } from 'react'
 import { ParagraphWrapper } from './Paragraph.styles'
+import { ResponsiveProps } from '../../utils/responsive'
 
 interface ParagraphProps {
   children: ReactNode
@@ -7,6 +8,7 @@ interface ParagraphProps {
   color?: CSSProperties['color']
   fontFamily?: CSSProperties['fontFamily']
   fontSize?: CSSProperties['fontSize']
+  responsive?: ResponsiveProps
 }
 
 export default function Paragraph({
@@ -15,6 +17,7 @@ export default function Paragraph({
   color,
   fontFamily,
   fontSize,
+  responsive
 }: ParagraphProps) {
   return (
     <ParagraphWrapper
@@ -24,6 +27,7 @@ export default function Paragraph({
         fontFamily,
         fontSize,
       }}
+      responsive={responsive}
     >
       {children}
     </ParagraphWrapper>

--- a/src/theme/base-theme.ts
+++ b/src/theme/base-theme.ts
@@ -1,0 +1,18 @@
+const theme = {
+    colors: {
+      header: '#333', // Default header color
+    },
+    fontSizes: {
+      h1: '32px',
+      h2: '28px',
+      h3: '24px',
+      h4: '20px',
+      h5: '16px',
+      h6: '14px',
+    },
+    fonts: {
+      header: 'Arial, sans-serif', // Default font for headers
+    },
+  }
+  
+  export default theme

--- a/src/theme/base-theme.ts
+++ b/src/theme/base-theme.ts
@@ -1,18 +1,21 @@
 const theme = {
-    colors: {
-      header: '#333', // Default header color
-    },
-    fontSizes: {
-      h1: '32px',
-      h2: '28px',
-      h3: '24px',
-      h4: '20px',
-      h5: '16px',
-      h6: '14px',
-    },
-    fonts: {
-      header: 'Arial, sans-serif', // Default font for headers
-    },
-  }
-  
-  export default theme
+  colors: {
+    header: '#333', // Default header color
+    paragraph: '#666', // Default paragraph color
+  },
+  fontSizes: {
+    h1: '32px',
+    h2: '28px',
+    h3: '24px',
+    h4: '20px',
+    h5: '16px',
+    h6: '14px',
+    paragraph: '16px', // Default paragraph font size
+  },
+  fonts: {
+    header: 'Arial, sans-serif', // Default font for headers
+    paragraph: 'Georgia, serif', // Default font for paragraphs
+  },
+}
+
+export default theme

--- a/src/theme/test-theme.ts
+++ b/src/theme/test-theme.ts
@@ -1,19 +1,21 @@
 const theme = {
-    colors: {
-      header: '#333', // Default header color
-    },
-    fontSizes: {
-      h1: '32px',
-      h2: '64px',
-      h3: '24px',
-      h4: '20px',
-      h5: '16px',
-      h6: '14px',
-    },
-    fonts: {
-      header: 'Arial, sans-serif', // Default font for headers
-    },
-  }
-  
-  export default theme
-  
+  colors: {
+    header: '#333', // Default header color
+    paragraph: '#666', // Default paragraph color
+  },
+  fontSizes: {
+    h1: '32px',
+    h2: '28px',
+    h3: '24px',
+    h4: '20px',
+    h5: '16px',
+    h6: '14px',
+    paragraph: '16px', // Default paragraph font size
+  },
+  fonts: {
+    header: 'Arial, sans-serif', // Default font for headers
+    paragraph: 'Georgia, serif', // Default font for paragraphs
+  },
+}
+
+export default theme

--- a/src/theme/test-theme.ts
+++ b/src/theme/test-theme.ts
@@ -1,0 +1,19 @@
+const theme = {
+    colors: {
+      header: '#333', // Default header color
+    },
+    fontSizes: {
+      h1: '32px',
+      h2: '64px',
+      h3: '24px',
+      h4: '20px',
+      h5: '16px',
+      h6: '14px',
+    },
+    fonts: {
+      header: 'Arial, sans-serif', // Default font for headers
+    },
+  }
+  
+  export default theme
+  

--- a/src/utils/breakpoints.ts
+++ b/src/utils/breakpoints.ts
@@ -1,0 +1,14 @@
+export const breakpoints = {
+  small: 576,  // Ends at 576px
+  medium: 768, // Ends at 768px
+  large: 992,  // Ends at 992px
+  xl: 1200,    // Starts at 993px
+}
+
+// Define media queries
+export const mediaQueries = {
+  small: `@media (max-width: ${breakpoints.small}px)`,
+  medium: `@media (min-width: ${breakpoints.small + 1}px) and (max-width: ${breakpoints.medium}px)`,
+  large: `@media (min-width: ${breakpoints.medium + 1}px) and (max-width: ${breakpoints.large}px)`,
+  xl: `@media (min-width: ${breakpoints.large + 1}px)`,
+}

--- a/src/utils/responsive.ts
+++ b/src/utils/responsive.ts
@@ -1,0 +1,22 @@
+import { mediaQueries } from './breakpoints'
+
+export type ResponsiveProps = {
+  small?: Partial<CSSStyleDeclaration>
+  medium?: Partial<CSSStyleDeclaration>
+  large?: Partial<CSSStyleDeclaration>
+  xl?: Partial<CSSStyleDeclaration>
+}
+
+export function generateResponsiveStyles(responsive?: ResponsiveProps): string {
+  if (!responsive) return ''
+
+  return Object.entries(responsive)
+    .map(([breakpoint, styles]) => {
+      const mediaQuery = mediaQueries[breakpoint as keyof typeof mediaQueries]
+      const stylesString = Object.entries(styles || {})
+        .map(([key, value]) => `${key}: ${value} !important;`)
+        .join('\n')
+      return `${mediaQuery} { ${stylesString} }`
+    })
+    .join('\n')
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1599,6 +1599,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/addon-viewport@npm:^8.4.4":
+  version: 8.4.4
+  resolution: "@storybook/addon-viewport@npm:8.4.4"
+  dependencies:
+    memoizerific: "npm:^1.11.3"
+  peerDependencies:
+    storybook: ^8.4.4
+  checksum: 10c0/de85220336d119fc1ff71fe78d54767985c1eb37cd4a03ccd43d5ccddd6f1d1e43aa73fb8f304eaa6e53c4a78234adc80482aa2f593ad272bc1389f1ec044805
+  languageName: node
+  linkType: hard
+
 "@storybook/blocks@npm:8.4.2, @storybook/blocks@npm:^8.4.2":
   version: 8.4.2
   resolution: "@storybook/blocks@npm:8.4.2"
@@ -4099,6 +4110,7 @@ __metadata:
     "@storybook/addon-essentials": "npm:^8.4.2"
     "@storybook/addon-interactions": "npm:^8.4.2"
     "@storybook/addon-onboarding": "npm:^8.4.2"
+    "@storybook/addon-viewport": "npm:^8.4.4"
     "@storybook/blocks": "npm:^8.4.2"
     "@storybook/react": "npm:^8.4.2"
     "@storybook/react-vite": "npm:^8.4.2"


### PR DESCRIPTION
This PR makes the following changes:

## New Features
- Adds base CSS options for the following components
  - Container 
  - Header
  - Paragraph

I'll need to go back and write official documentation on all these once they are more fleshed out. Overall its basic CSS pass-through with `responsive` options that use the screen width to dynamically change sizes of things.  

## Testing
 - Add `main` storybook file for complex and cohesive examples of components 

## Known Issues
- The `Header` component has a lot of known issues that I have come to realize. As of right now you can adjust what header size to use when using the `responsive` property which is the whole point of the feature.